### PR TITLE
new prop to handle wallet UI button as modal

### DIFF
--- a/src/WalletUI.tsx
+++ b/src/WalletUI.tsx
@@ -26,8 +26,8 @@ export function useWalletUI(){
 	return({...props})	
 }
 
-export default function WalletUI({primary, textColor, backgroundColor} : { primary?: string, textColor?: string, backgroundColor?: string }) {
-	const [open, setOpen] = useState(false)
+export default function WalletUI({primary, textColor, backgroundColor, openState} : { primary?: string, textColor?: string, backgroundColor?: string, openState: boolean}) {
+	const [open, setOpen] = useState(openState ?? false )
 	const { providers, activeAccount } = useWallet()
 
 	return (


### PR DESCRIPTION
Proposed changes so that the prop can be managed outside like a modal without needing to directly click on the button to modify the setOpen to false